### PR TITLE
test: migrate first e2e test to v2 executor CRD

### DIFF
--- a/library/multi-tenancy-validation/template.yaml
+++ b/library/multi-tenancy-validation/template.yaml
@@ -19,7 +19,7 @@ spec:
           images_ephemeral := [img | img = concat("", ["[",input.review.object.metadata.namespace,"]",input.review.object.spec.ephemeralContainers[_].image])]
           other_images := array.concat(images_init, images_ephemeral)
           all_images := array.concat(other_images, images)
-          response := external_data({"provider": "ratify-provider", "keys": all_images})
+          response := external_data({"provider": "ratify-gatekeeper-provider", "keys": all_images})
         }
 
         # Base Gatekeeper violation
@@ -43,6 +43,6 @@ spec:
         # Check if the success criteria is true
         general_violation[{"result": result}] {
           subject_validation := remote_data.responses[_]
-          subject_validation[1].isSuccess == false
-          result := sprintf("Time=%s, failed to verify the artifact: %s, trace-id: %s", [subject_validation[1].timestamp, subject_validation[0], subject_validation[1].traceID])
+          subject_validation[1].succeeded == false
+          result := sprintf("Artifact failed verification: %s, \nreport: %v", [subject_validation[0], subject_validation[1]])
         }

--- a/test/bats/base-test.bats
+++ b/test/bats/base-test.bats
@@ -22,7 +22,6 @@ RATIFY_NAME=ratify
 RATIFY_NAMESPACE=gatekeeper-system
 
 @test "base test without cert rotator" {
-    skip "TODO: migrate to v2 executor CRD"
     teardown() {
         echo "cleaning up"
         wait_for_process ${WAIT_TIME} ${SLEEP_TIME} 'kubectl delete pod demo --namespace default --force --ignore-not-found=true'
@@ -36,9 +35,8 @@ RATIFY_NAMESPACE=gatekeeper-system
     run kubectl apply -f ./library/multi-tenancy-validation/samples/constraint.yaml
     assert_success
     sleep 5
-    # validate key management provider status property shows success
-    run bash -c "kubectl get keymanagementproviders.config.ratify.deislabs.io/ratify-notation-inline-cert-0 -o yaml | grep 'issuccess: true'"
-    assert_success
+    # wait for executor to be reconciled by controller
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get executors.config.ratify.dev -n ${RATIFY_NAMESPACE} -o jsonpath='{.items[0].status.succeeded}' | grep true"
     run kubectl run demo --namespace default --image=registry:5000/notation:signed
     assert_success
     run kubectl run demo1 --namespace default --image=registry:5000/notation:unsigned


### PR DESCRIPTION
Migrate "base test without cert rotator" from v1 CRDs to v2 Executor CRD architecture. Other tests are temporarily skipped pending migration.

Key changes:
- Makefile: update chart paths (charts/ratify → deployments/ratify-gatekeeper-provider), helm install values to match v2 chart schema, fix generate-certs service name, add trivy DB fallback download, update Dockerfile path
- executor.yaml template: fix inline cert format ({certs: PEM} not bare string)
- executor.go: add stripNamespacePrefix for gatekeeper artifact refs
- base-test.bats: add setup_file with webhook probe, use v2 constraint template (succeeded field), skip remaining tests for incremental migration
- Add v2 constraint template and constraint fixture files
- e2e-k8s.yml: fix save logs pod label for v2 chart

## Description

<!-- Please include a summary of the changes and relevant context. -->

### Which issue(s) does this PR resolve?

<!--
    Use `Fixes #<issue number>[, Fixes #<issue_number>, ...]` format.
    Use `Fixes` for bug fixes and `Resolves` for new features.
    The PR will close the issue(s) when it gets merged.
-->
Fixes #

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Helm chart change (any edit/addition/update that is necessary for changes merged to the `main` branch)
- This change requires a documentation update

## Testing and verification

<!-- Please describe the tests you ran to verify your changes, including any relevant configuration details. -->

## Checklist

- [ ] Does the affected code have corresponding tests?
- [ ] Are the changes documented, not just with inline documentation, but also with conceptual documentation such as an overview of a new feature, or task-based documentation like a tutorial? Consider if this change should be announced on your project blog.
- [ ] Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ] Do all new files have appropriate license header?

## Post merge requirements

- [ ] MAINTAINERS: manually trigger the "Publish Package" workflow after merging any PR that indicates `Helm Chart Change`
